### PR TITLE
problem selection just selects the most recent problems.

### DIFF
--- a/hooks/useProblems.ts
+++ b/hooks/useProblems.ts
@@ -142,9 +142,9 @@ const useProblems = (user: User | null | undefined) => {
       }
 
       if (newPool.unsolved.length > 0) {
-        problem = newPool.unsolved[Math.floor(Math.random() * newPool.unsolved.length)];
+        problem = newPool.unsolved[Math.floor(Math.random() * Math.min(20, newPool.unsolved.length))];
       } else {
-        problem = newPool.solved[Math.floor(Math.random() * newPool.solved.length)];
+        problem = newPool.solved[Math.floor(Math.random() * Math.min(20, newPool.solved.length))];
       }
       return {
         ...problem,


### PR DESCRIPTION
hi. the problem selection script was selecting randomly between all problems rating X on codeforces. because old problems aren't really useful anymore and don't match their rating. i just made tiny change in the code so that the problems it selects are from the recent 20 problems of the same rating in codeforces. 