### PR TITLE
Feature: Set limits on CF Rounds considered.

### DIFF
--- a/app/training/page.tsx
+++ b/app/training/page.tsx
@@ -9,8 +9,10 @@ import TagSelector from "@/components/TagSelector";
 import Loader from "@/components/Loader";
 import Error from "@/components/Error";
 import useTags from "@/hooks/useTags";
+import useBounds from "@/hooks/useBounds";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Textboxpair } from "@/components/ui/textboxpair";
 
 const Training = () => {
   const { user } = useUser();
@@ -26,6 +28,11 @@ const Training = () => {
     finishTraining,
     generateProblems,
   } = useTraining();
+  const { firstInput,
+    secondInput,
+    onFirstInputChange,
+    onSecondInputChange
+  } = useBounds();
   const [showRatings, setShowRatings] = useState(false);
 
   if (isLoading) {
@@ -54,15 +61,18 @@ const Training = () => {
           onClearTags={onClearTags}
         />
         <div className="flex flex-col gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setShowRatings(!showRatings)}
-            className="w-fit"
-          >
-            {showRatings ? "Hide Ratings" : "Show Ratings"}
-          </Button>
-          
+          <div className="flex place-content-between">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowRatings(!showRatings)}
+              className="w-fit">
+              {showRatings ? "Hide Ratings" : "Show Ratings"}
+            </Button>
+            <Textboxpair onFirstInputChange={onFirstInputChange} onSecondInputChange={onSecondInputChange}></Textboxpair>
+          </div>
+
+
           <div className="flex flex-wrap gap-4 p-4 rounded-lg justify-between">
             <div>
               <span className="font-bold">P1:</span>{" "}
@@ -100,6 +110,8 @@ const Training = () => {
           refreshProblemStatus={refreshProblemStatus}
           finishTraining={finishTraining}
           selectedTags={selectedTags}
+          lb={firstInput}
+          ub={secondInput}
         />
       </CardContent>
     </Card>

--- a/components/Trainer.tsx
+++ b/components/Trainer.tsx
@@ -47,16 +47,20 @@ const Trainer = ({
   refreshProblemStatus,
   finishTraining,
   selectedTags,
+  lb,
+  ub,
 }: {
   isTraining: boolean;
   training: Training | null;
   problems: TrainingProblem[] | null;
-  generateProblems: (tags: ProblemTag[]) => void;
+  generateProblems: (tags: ProblemTag[], lb: number, ub: number) => void;
   startTraining: () => void;
   stopTraining: () => void;
   refreshProblemStatus: () => void;
   finishTraining: () => void;
   selectedTags: ProblemTag[];
+  lb: number;
+  ub: number;
 }) => {
   const onFinishTraining = () => {
     if (confirm("Are you sure to finish the training?")) {
@@ -93,7 +97,7 @@ const Trainer = ({
           {!isTraining ? (
             <>
               <Button
-                onClick={() => generateProblems(selectedTags)}
+                onClick={() => generateProblems(selectedTags,lb,ub)}
               >
                 {problems && problems.length > 0 ? "Regenerate" : "Generate Problems"}
               </Button>

--- a/components/ui/textboxpair.tsx
+++ b/components/ui/textboxpair.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import * as React from "react"
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+
+interface TextboxpairProps extends React.HTMLAttributes<HTMLDivElement> {
+  onFirstInputChange: (e: string) => void;
+  onSecondInputChange: (e: string) => void;
+}
+
+const Textboxpair = React.forwardRef<HTMLDivElement, TextboxpairProps>((props, ref) => {
+  // Destructure the event handlers and other props separately
+  const { onFirstInputChange, onSecondInputChange, ...otherProps } = props;
+
+  return (
+      <div ref={ref} className="flex gap-1" {...otherProps}>
+        <Modded_input
+          type="text"
+          placeholder="Oldest Round"
+          onChange={(e) => onFirstInputChange(e.target.value)}
+        />
+        <Modded_input
+          type="text"
+          placeholder="Newest Round"
+          onChange={(e) => onSecondInputChange(e.target.value)}
+        />
+      </div>
+  )
+})
+Textboxpair.displayName = "Textboxpair"
+
+const Modded_input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, onChange, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        onChange={onChange}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Modded_input.displayName = "Modded_input"
+
+export { Textboxpair }

--- a/hooks/useBounds.ts
+++ b/hooks/useBounds.ts
@@ -1,0 +1,23 @@
+import { useState } from "react";
+
+const useBounds = () => {
+  const [firstInput, setFirstInput] = useState(1);
+  const [secondInput, setSecondInput] = useState(3000);
+
+  const onFirstInputChange = (val: string) => {
+    setFirstInput(parseInt(val));
+  };
+
+  const onSecondInputChange = (val: string) => {
+    setSecondInput(parseInt(val));
+  };
+
+  return {
+    firstInput,
+    secondInput,
+    onFirstInputChange,
+    onSecondInputChange
+  };
+};
+
+export default useBounds;

--- a/hooks/useTraining.ts
+++ b/hooks/useTraining.ts
@@ -224,8 +224,8 @@ const useTraining = () => {
     localStorage.removeItem(TRAINING_STORAGE_KEY);
   };
 
-  const generateProblems = (tags: ProblemTag[]) => {
-    const newProblems = getRandomProblems(tags);
+  const generateProblems = (tags: ProblemTag[], lb: number, ub: number) => {
+    const newProblems = getRandomProblems(tags, lb, ub);
     if (newProblems) {
       setProblems(newProblems);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-scroll-area": "^1.2.1",
         "@radix-ui/react-separator": "^1.1.0",
+        "@radix-ui/react-slider": "^1.2.2",
         "@radix-ui/react-slot": "^1.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1446,6 +1447,127 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.2.2.tgz",
+      "integrity": "sha512-sNlU06ii1/ZcbHf8I9En54ZPW0Vil/yPVg4vQMcFNjrIx51jsHbFl1HYHQvCIWJSr1q0ZmA+iIs/ZTv8h7HHSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.1.tgz",
+      "integrity": "sha512-LwT3pSho9Dljg+wY2KN2mrrh6y3qELfftINERIzBUO9e0N+t0oMTyn3k9iv+ZqgrwGkRnLpNJrsMv9BZlt2yuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
@@ -1519,6 +1641,21 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
       "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-scroll-area": "^1.2.1",
     "@radix-ui/react-separator": "^1.1.0",
+    "@radix-ui/react-slider": "^1.2.2",
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/utils/getPerformance.ts
+++ b/utils/getPerformance.ts
@@ -50,6 +50,6 @@ const getPerformance = (training: Training) => {
   }
 
   return Math.round(performance);
-}
+};
 
 export default getPerformance;


### PR DESCRIPTION
- Added code to set upper and lower limits on the range of CF Rounds considered for generating the problems, so user can get recent problems in recent meta.
- Fixed a tiny bug where single problem may get produced for two positions. For eg if P3 and P4 are both at 1200 rating (when math.random isn't random enough sometimes) 
 [Amend]:
- Added UI textboxes to take user input of CF Round Limits.
- hooks/useBound, components/ui/textboxpair files added.
